### PR TITLE
Transactional dont rollback on unchecked exception

### DIFF
--- a/voidframework-persistence-hibernate/src/main/java/dev/voidframework/persistence/hibernate/module/TransactionalInterceptor.java
+++ b/voidframework-persistence-hibernate/src/main/java/dev/voidframework/persistence/hibernate/module/TransactionalInterceptor.java
@@ -119,7 +119,8 @@ public class TransactionalInterceptor implements MethodInterceptor {
         }
 
         // If the list is empty, you simply need to rollback
-        if (transactionalAnnotation.rollbackOn().length == 0) {
+        if (transactionalAnnotation.rollbackOn().length == 0
+            && RuntimeException.class.isAssignableFrom(throwableClass)) {
             return true;
         }
 


### PR DESCRIPTION
In accordance with the documentation for the "Transactional" annotation, by default a rollback should take place when an unchecked exception occurs.