### PR TITLE
Session signature key configuration is now required

### DIFF
--- a/sample-project/src/main/resources/application.conf
+++ b/sample-project/src/main/resources/application.conf
@@ -14,6 +14,14 @@ voidframework {
 
     web {
         globalFilters += "filter.SecurityHeaderFilter"
+
+        csrf {
+            signatureKey = "1Wq5MkhqAx7AsYTt214U5k1Bq6qdfvtbBtRfNvU80g1osZmFjC6ojEEPRR3rh6dE"
+        }
+
+        session {
+            signatureKey = "sDbHiQvZqAVQlv5J5hyAGFTqg1YvPVQP91g8yNSm6uu7yD6nALtHMHdFFM5nkdF2"
+        }
     }
 
     cache {

--- a/voidframework-web/src/main/resources/reference.conf
+++ b/voidframework-web/src/main/resources/reference.conf
@@ -72,8 +72,8 @@ voidframework {
             # Is the cookie secured? If true, sent only for HTTPS requests
             cookieSecure = false
 
-            # Crypto key is used to secure the session content
-            cryptoKey = "sDbHiQvZqAVQlv5J5hyAGFTqg1YvPVQP91g8yNSm6uu7yD6nALtHMHdFFM5nkdF2"
+            # Signature key is used to secure the session content
+            signatureKey = "changeme"
 
             # Defines the session TTL. According to the documentation, the
             # following units can be used :
@@ -101,12 +101,18 @@ voidframework {
             # Is the CSRF cookie secured? If true, sent only for HTTPS requests
             cookieSecure = ${voidframework.web.session.cookieSecure}
 
-            # Crypto key is used to secure the CSRF token
-            cryptoKey = "1Wq5MkhqAx7AsYTt214U5k1Bq6qdfvtbBtRfNvU80g1osZmFjC6ojEEPRR3rh6dE"
+            # Signature key is used to secure the CSRF token
+            signatureKey = ${voidframework.web.session.signatureKey}
 
-            # Defines the time to live (TTL) in milliseconds of a CSRF Token
-            # Default value: 900000 (15 minutes)
-            timeToLive = 900000
+            # Defines the time to live (TTL) of a single CSRF Token
+            # The following units can be used :
+            #  - s, seconds
+            #  - m, minutes
+            #  - h, hours
+            #  - d, days
+            #
+            # ie: timeToLive = "15 minutes"
+            timeToLive = "15 minutes"
         }
 
         # Server configuration


### PR DESCRIPTION
It is now mandatory to define the signing key to be used to sign the session data. By default, this signature will also be used for the CSRF token.