### PR TITLE
Force EntityManagerFactory initialization during boot sequence

### DIFF
--- a/sample-project/src/main/resources/application.conf
+++ b/sample-project/src/main/resources/application.conf
@@ -1,7 +1,6 @@
 voidframework {
 
     core {
-
         runInDevMode = true
 
         acceptedScanPaths += "controller"
@@ -10,6 +9,10 @@ voidframework {
         acceptedScanPaths += "service"
         acceptedScanPaths += "filter"
         #rejectedScanPaths += "dev.voidframework.web.healthcheck"
+    }
+
+    persistence {
+        modelsJarUrlPattern = "^.*void.*$"
     }
 
     web {

--- a/voidframework-migration-flyway/src/main/java/dev/voidframework/migration/flyway/FlywayMigration.java
+++ b/voidframework-migration-flyway/src/main/java/dev/voidframework/migration/flyway/FlywayMigration.java
@@ -2,7 +2,6 @@ package dev.voidframework.migration.flyway;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.google.inject.Singleton;
 import com.typesafe.config.Config;
 import dev.voidframework.core.bindable.BindClass;
 import dev.voidframework.core.lifecycle.LifeCycleStart;
@@ -19,7 +18,6 @@ import java.util.List;
  * Flyway migration.
  */
 @BindClass
-@Singleton
 public final class FlywayMigration {
 
     private final Config configuration;

--- a/voidframework-persistence-hibernate/src/main/java/dev/voidframework/persistence/hibernate/module/EntityManagerProvider.java
+++ b/voidframework-persistence-hibernate/src/main/java/dev/voidframework/persistence/hibernate/module/EntityManagerProvider.java
@@ -191,6 +191,7 @@ public class EntityManagerProvider implements Provider<EntityManager> {
      * @return The newly created URL
      */
     private URL createURL(final String urlAsString) {
+
         try {
             return new URL(urlAsString);
         } catch (final MalformedURLException ignore) {

--- a/voidframework-persistence-hibernate/src/main/java/dev/voidframework/persistence/hibernate/module/PersistenceLifeCycle.java
+++ b/voidframework-persistence-hibernate/src/main/java/dev/voidframework/persistence/hibernate/module/PersistenceLifeCycle.java
@@ -1,0 +1,74 @@
+package dev.voidframework.persistence.hibernate.module;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.name.Names;
+import com.typesafe.config.Config;
+import dev.voidframework.core.bindable.BindClass;
+import dev.voidframework.core.lifecycle.LifeCycleStart;
+import dev.voidframework.exception.DataSourceException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This LifeCycle allows to force the initialization of the EntityManagerFactory.
+ */
+@BindClass
+public final class PersistenceLifeCycle {
+
+    private final Config configuration;
+    private final Injector injector;
+
+    /**
+     * Build a new instance.
+     *
+     * @param configuration The application configuration
+     * @param injector      The injector instance
+     */
+    @Inject
+    public PersistenceLifeCycle(final Config configuration,
+                                final Injector injector) {
+
+        this.configuration = configuration;
+        this.injector = injector;
+    }
+
+    /**
+     * Force {@link EntityManagerFactory} initialization for each configured data sources.
+     */
+    @LifeCycleStart(priority = 51)
+    public void forceEntityManagerFactoryInitialisation() {
+
+        if (!this.configuration.hasPathOrNull("voidframework.datasource")) {
+            throw new DataSourceException.NotConfigured();
+        }
+
+        final Set<String> dbConfigurationNameSet = this.configuration.getConfig("voidframework.datasource").entrySet()
+            .stream()
+            .map(Map.Entry::getKey)
+            .map(key -> {
+                if (key.contains(".")) {
+                    return key.substring(0, key.indexOf("."));
+                } else {
+                    return key;
+                }
+            })
+            .collect(Collectors.toSet());
+
+        for (final String dbConfigurationName : dbConfigurationNameSet) {
+            final Key<EntityManager> key = Key.get(EntityManager.class, Names.named(dbConfigurationName));
+            final Provider<EntityManager> entityManagerProvider = this.injector.getProvider(key);
+
+            final EntityManager entityManager = entityManagerProvider.get();
+            if (entityManager != null) {
+                entityManager.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
`EntityManagerFactory` is only initialized when it is going to be used, which can strongly slow down the first requests. This modification allows to force the initialization when starting the application.