### PR TITLE
Upgrade Undertow version to 2.2.19 (CVE-2022-2053)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency.version.logback>1.2.11</dependency.version.logback>
         <dependency.version.tika>2.4.1</dependency.version.tika>
         <dependency.version.typesafeconfig>1.4.2</dependency.version.typesafeconfig>
-        <dependency.version.undertow>2.2.18.Final</dependency.version.undertow>
+        <dependency.version.undertow>2.2.19.Final</dependency.version.undertow>
 
         <!-- Unit Tests -->
         <dependency.version.h2>2.1.214</dependency.version.h2>


### PR DESCRIPTION
When a POST request comes through AJP and the request exceeds the max-post-size limit (maxEntitySize), Undertow's AjpServerRequestConduit implementation closes a connection without sending any response to the client/proxy. This behavior results in that a front-end proxy marking the backend worker (application server) as an error state and not forward requests to the worker for a while.

CWE-400
CVE-2022-2053