### PR TITLE
Upgrade Undertow version to 2.3.5 (CVE-2022-4492)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency.version.logback>1.4.5</dependency.version.logback>
         <dependency.version.tika>2.7.0</dependency.version.tika>
         <dependency.version.typesafeconfig>1.4.2</dependency.version.typesafeconfig>
-        <dependency.version.undertow>2.3.3.Final</dependency.version.undertow>
+        <dependency.version.undertow>2.3.5.Final</dependency.version.undertow>
 
         <!-- Unit Tests -->
         <dependency.version.hsqldb>2.7.1</dependency.version.hsqldb>


### PR DESCRIPTION
The undertow client is not checking the server identity presented by the server certificate in https connections. This should be performed by default in https and in http/2.