### PR TITLE
Upgrade Undertow to 2.3.17 (CVE-2024-7885)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency.version.retrofit>2.11.0</dependency.version.retrofit>
         <dependency.version.tika>2.9.2</dependency.version.tika>
         <dependency.version.typesafeconfig>1.4.3</dependency.version.typesafeconfig>
-        <dependency.version.undertow>2.3.14.Final</dependency.version.undertow>
+        <dependency.version.undertow>2.3.17.Final</dependency.version.undertow>
 
         <!-- Unit Tests -->
         <dependency.version.hsqldb>2.7.3</dependency.version.hsqldb>


### PR DESCRIPTION
A vulnerability was found in Undertow where the ProxyProtocolReadListener reuses the same StringBuilder instance across multiple requests. This issue occurs when the parseProxyProtocolV1 method processes multiple requests on the same HTTP connection. CWE-362 / CVE-2024-7885.